### PR TITLE
Download artifact using Puppet http client

### DIFF
--- a/tasks/utils/artifact.rb
+++ b/tasks/utils/artifact.rb
@@ -13,9 +13,16 @@ class Artifact
   end
 
   def download(url)
-    Puppet::Util::Execution.execute %(curl --cert "#{hostcert}" --key "#{hostprivkey}" --output #{@tmp_file.path} --fail #{url}),
-                                    failonfail: true,
-                                    combine: true
+    client = Puppet.runtime[:http]
+    client.get(URI(url), options: { include_system_store: true }) do |response|
+      if response.success?
+        File.open(@tmp_file.path, 'w') do |f|
+          response.read_body do |data|
+            f.write(data)
+          end
+        end
+      end
+    end
   end
 
   def extract_to(path)


### PR DESCRIPTION
Drop dependency on curl(1).  As a bonus this make it easier for us to download artifacts using an user account that has no access to Puppet's certificate (i.e. the deploy user).

This PR also include:
* #1 
* #2 