### PR TITLE
Add support for non tar-bomb artifacts

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -3,4 +3,5 @@ Gemfile:
   optional:
     ':test':
       - gem: cucumber
+      - gem: minitar
       - gem: mtree

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :test do
   gem 'voxpupuli-test', '~> 2.1',  :require => false
   gem 'simplecov-console',         :require => false
   gem 'cucumber',                  :require => false
+  gem 'minitar',                   :require => false
   gem 'mtree',                     :require => false
 end
 group :development do

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1,8 +1,8 @@
 require_relative '../../tasks/utils/application'
 
 Given('an application {string}') do |application|
-  tmp_dir = Dir.mktmpdir
-  @application_dir = "#{tmp_dir}/#{application}"
+  @tmp_dir = Dir.mktmpdir
+  @application_dir = "#{@tmp_dir}/#{application}"
   @application = Application.new(name: application, path: @application_dir)
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,3 +8,8 @@ def workaround_async_ci
   sleep(0.1)
   `sync`
 end
+
+After do
+  FileUtils.rm_r(@tmp_dir) if @tmp_dir
+  @tmp_dir = nil
+end

--- a/spec/unit/tasks/utils/deployment_spec.rb
+++ b/spec/unit/tasks/utils/deployment_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe Deployment do
 
   let(:path) { Dir.mktmpdir }
 
+  after do
+    FileUtils.rm_r(path)
+  end
+
   describe '#activate' do
     before do
       allow(application).to receive(:current_link_path).and_return("#{path}/current")

--- a/tasks/utils/artifact.rb
+++ b/tasks/utils/artifact.rb
@@ -36,26 +36,4 @@ class Artifact
   def unlink
     @tmp_file.unlink
   end
-
-  private
-
-  def puppet_setting(setting)
-    unless Puppet.settings.app_defaults_initialized?
-      Puppet.settings.preferred_run_mode = :agent
-
-      Puppet.settings.initialize_global_settings([])
-      Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(Puppet.run_mode))
-      Puppet.push_context(Puppet.base_context(Puppet.settings))
-    end
-
-    Puppet.settings[setting]
-  end
-
-  def hostcert
-    puppet_setting(:hostcert)
-  end
-
-  def hostprivkey
-    puppet_setting(:hostprivkey)
-  end
 end


### PR DESCRIPTION
If an artifact content is contained in a single directory, strip it on extraction and make it's name available as `deployment_name`.

This will allow us to guess the name of deployments when downloading its artifact.