### PR TITLE
Add a task to prune old deployments

### DIFF
--- a/features/deployments.feature
+++ b/features/deployments.feature
@@ -8,27 +8,8 @@ Feature: Deployments
     Then the deployment "v2-works" should exist
     Then the symbolic link "current" should point to "v2-works"
 
-  Scenario: Remove an old deployment
-    Given an application "app1"
-    And the following deployments:
-      | name |
-      | v1   |
-      | v2   |
-      | v3   |
-    When I remove the deployment "v2"
-    Then the deployments should be:
-      | name |
-      | v1   |
-      | v3   |
-    When I remove the deployment "v3" catching errors
-    Then the error "Cannot remove the active deployment" should have been catch
-    And the deployments should be:
-      | name |
-      | v1   |
-      | v3   |
 
   Scenario: Prune old deployments
-    Up to 5 deployments are kept on disk.  When this limit is reached, least recently used deployments are pruned.
     Given an application "app1"
     And the following deployments:
       | name     |
@@ -37,83 +18,19 @@ Feature: Deployments
       | v3-works |
       | v4-works |
       | v5-works |
-    When I create a deployment "v6-broken"
-    Then the deployments should be:
-      | name      |
-      | v2-works  |
-      | v3-works  |
-      | v4-works  |
-      | v5-works  |
-      | v6-broken |
-    When I activate the deployment "v5-works"
-    Then the deployments should be:
-      | name      |
-      | v2-works  |
-      | v3-works  |
-      | v4-works  |
-      | v6-broken |
-      | v5-works  |
-    When I create a deployment "v7-broken"
+    When I prune old deployments keeping the last 3
     Then the deployments should be:
       | name      |
       | v3-works  |
       | v4-works  |
-      | v6-broken |
       | v5-works  |
-      | v7-broken |
-    When I activate the deployment "v5-works"
+    When I prune old deployments keeping the last 10
     Then the deployments should be:
       | name      |
       | v3-works  |
       | v4-works  |
-      | v6-broken |
-      | v7-broken |
       | v5-works  |
-    When I create a deployment "v8-broken"
+    When I prune old deployments keeping the last 1
     Then the deployments should be:
       | name      |
-      | v4-works  |
-      | v6-broken |
-      | v7-broken |
       | v5-works  |
-      | v8-broken |
-    When I activate the deployment "v5-works"
-    Then the deployments should be:
-      | name      |
-      | v4-works  |
-      | v6-broken |
-      | v7-broken |
-      | v8-broken |
-      | v5-works  |
-    When I create a deployment "v9-broken"
-    Then the deployments should be:
-      | name      |
-      | v6-broken |
-      | v7-broken |
-      | v8-broken |
-      | v5-works  |
-      | v9-broken |
-    When I activate the deployment "v5-works"
-    Then the deployments should be:
-      | name      |
-      | v6-broken |
-      | v7-broken |
-      | v8-broken |
-      | v9-broken |
-      | v5-works  |
-    When I create a deployment "v10-broken"
-    Then the deployments should be:
-      | name       |
-      | v7-broken  |
-      | v8-broken  |
-      | v9-broken  |
-      | v5-works   |
-      | v10-broken |
-    When I activate the deployment "v5-works"
-    Then the deployments should be:
-      | name       |
-      | v7-broken  |
-      | v8-broken  |
-      | v9-broken  |
-      | v10-broken |
-      | v5-works   |

--- a/features/deployments.feature
+++ b/features/deployments.feature
@@ -8,6 +8,19 @@ Feature: Deployments
     Then the deployment "v2-works" should exist
     Then the symbolic link "current" should point to "v2-works"
 
+  Scenario: Activate an old deployment
+    Given an application "app1"
+    And the following deployments:
+      | name |
+      | v1   |
+      | v2   |
+      | v3   |
+    When I activate the deployment "v2"
+    Then the deployments should be:
+      | name |
+      | v1   |
+      | v3   |
+      | v2   |
 
   Scenario: Prune old deployments
     Given an application "app1"

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -34,6 +34,10 @@ When('I remove the deployment {string} catching errors') do |name|
   end
 end
 
+When('I prune old deployments keeping the last {int}') do |keep|
+  @application.prune(keep)
+end
+
 Then('the current deployment should be {string}') do |target|
   step(%(the symbolic link "current" should point to "#{target}"))
 end

--- a/tasks/prune.json
+++ b/tasks/prune.json
@@ -1,0 +1,27 @@
+{
+  "description": "Prune old deployments of an application",
+  "input_method": "stdin",
+  "files": [
+    "application/tasks/utils/application_factory.rb",
+    "application/tasks/utils/application.rb",
+    "application/tasks/utils/applications_helper.rb",
+    "application/tasks/utils/artifact.rb",
+    "application/tasks/utils/deployment.rb",
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "parameters": {
+    "application": {
+      "description": "The application to operate on",
+      "type": "String[1]"
+    },
+    "environment": {
+      "description": "The environment to operate on",
+      "type": "String[1]"
+    },
+    "keep": {
+      "description": "The number of MRU deployments to keep",
+      "type": "Integer[1]",
+      "default": 5
+    }
+  }
+}

--- a/tasks/prune.rb
+++ b/tasks/prune.rb
@@ -1,0 +1,20 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'open3'
+
+require_relative '../../ruby_task_helper/files/task_helper'
+
+require_relative 'utils/application_factory'
+
+class ApplicationPruneTask < TaskHelper
+  def task(application:, environment:, keep:, **_kwargs)
+    ApplicationFactory.find(application, environment).each do |app|
+      app.prune(keep)
+    end
+
+    nil
+  end
+end
+
+ApplicationPruneTask.run if $PROGRAM_NAME == __FILE__

--- a/tasks/utils/application.rb
+++ b/tasks/utils/application.rb
@@ -22,7 +22,6 @@ class Application
     deployment = Deployment.create(self, deployment_name, url)
 
     deployment.activate
-    prune_old_deployments
   end
 
   def deployments
@@ -82,8 +81,10 @@ class Application
     File.join(path, PERSISTENT_DATA)
   end
 
-  def prune_old_deployments
-    extra_deployments = deployments.values.sort_by(&:updated_at).slice(0...-5)
+  def prune(keep)
+    extra_deployments = deployments.values.sort_by(&:updated_at).slice(0...-keep)
+
+    # If there are less than keep deployments, do not attempt to remove the current one.
     extra_deployments.delete(current_deployment)
 
     extra_deployments.each(&:remove)


### PR DESCRIPTION
Do not auto-prune deployments, add a task to do this operation and make
the number of kept deployments tunable.
