### PR TITLE
Infer deployment name from artifact

### DIFF
--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -30,11 +30,15 @@ class Deployment
   end
 
   def deploy(url)
+    artifact = Artifact.new(url)
+    @name ||= artifact.deployment_name
+
+    raise 'Cannot infer deployment name and none specified' if name.nil?
+
     create_deployment_directory
     begin
       raise 'Aborted deployment: before_deploy hook failed' unless run_hook('before_deploy')
 
-      artifact = Artifact.new(url)
       artifact.extract_to(full_path)
       artifact.unlink
 


### PR DESCRIPTION
If no deployment name is provided and the artifact has all it files
contained in a single root directory, use this root directory name as
the name of the deployment.
