### PR TITLE
Add minitar as a gem dependency

### DIFF
--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -2,4 +2,4 @@
 application::common::configuration_root: /usr/local/etc/applications
 application::common::configuration_user: root
 application::common::configuration_group: wheel
-application::common::mtree_provider: gem
+application::common::gem_dependencies_provider: gem

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,4 +2,4 @@
 application::common::configuration_root: /etc/applications
 application::common::configuration_user: root
 application::common::configuration_group: root
-application::common::mtree_provider: puppet_gem
+application::common::gem_dependencies_provider: puppet_gem

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -5,7 +5,7 @@ class application::common (
   Stdlib::Absolutepath $configuration_root,
   String[1] $configuration_user,
   String[1] $configuration_group,
-  Enum['gem', 'puppet_gem'] $mtree_provider,
+  Enum['gem', 'puppet_gem'] $gem_dependencies_provider,
 ) {
   assert_private()
 
@@ -25,5 +25,5 @@ class application::common (
     mode   => '0644',
   }
 
-  ensure_packages('mtree', { ensure => installed, provider => $mtree_provider })
+  ensure_packages(['minitar', 'mtree'], { ensure => installed, provider => $gem_dependencies_provider })
 }


### PR DESCRIPTION
minitar dependency was introduced in 8779bf9ea378d4d13c52c654fa4e8987cb56d540 but not added to what the puppet code manage.