### PR TITLE
Drop created_at

### DIFF
--- a/spec/unit/tasks/utils/deployment_spec.rb
+++ b/spec/unit/tasks/utils/deployment_spec.rb
@@ -34,23 +34,6 @@ RSpec.describe Deployment do
     it { expect { deployment.activate }.not_to raise_exception }
   end
 
-  describe '#created_at' do
-    subject { deployment.created_at }
-
-    let(:ctime) { double }
-    let(:stat) do
-      stat = double
-      allow(stat).to receive(:ctime).and_return(ctime)
-      stat
-    end
-
-    before do
-      allow(File).to receive(:stat).with("#{path}/12345678").and_return(stat)
-    end
-
-    it { is_expected.to eq(ctime) }
-  end
-
   describe '#<=>' do
     subject { deployment == other }
 

--- a/tasks/activate.rb
+++ b/tasks/activate.rb
@@ -1,8 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 # frozen_string_literal: true
 
-require 'open3'
-
 require_relative '../../ruby_task_helper/files/task_helper'
 
 require_relative 'utils/application_factory'

--- a/tasks/deploy.rb
+++ b/tasks/deploy.rb
@@ -1,8 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 # frozen_string_literal: true
 
-require 'open3'
-
 require_relative '../../ruby_task_helper/files/task_helper'
 
 require_relative 'utils/application_factory'

--- a/tasks/prune.rb
+++ b/tasks/prune.rb
@@ -1,8 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 # frozen_string_literal: true
 
-require 'open3'
-
 require_relative '../../ruby_task_helper/files/task_helper'
 
 require_relative 'utils/application_factory'

--- a/tasks/remove.rb
+++ b/tasks/remove.rb
@@ -1,8 +1,6 @@
 #!/opt/puppetlabs/puppet/bin/ruby
 # frozen_string_literal: true
 
-require 'open3'
-
 require_relative '../../ruby_task_helper/files/task_helper'
 
 require_relative 'utils/application_factory'

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -116,6 +116,8 @@ class Deployment
       Process.gid = application.deploy_group if application.deploy_group
       Process.uid = application.deploy_user  if application.deploy_user
 
+      ENV.delete_if { |variable| variable !~ /^LC_/ }
+
       ENV['APPLICATION'] = application.name
       ENV['ENVIRONMENT'] = application.environment
       ENV['DEPLOYMENT_NAME'] = name

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -131,7 +131,7 @@ class Deployment
       end
 
       FileUtils.chdir(full_path) do
-        exec(hook)
+        Process.exec(hook)
       end
     end
 

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -83,10 +83,6 @@ class Deployment
     run_hook('after_activate')
   end
 
-  def created_at
-    File.stat(full_path).ctime
-  end
-
   def updated_at
     File.stat(full_path).mtime
   end


### PR DESCRIPTION
ctime and mtime are the same as far as we are concerned here, and
birthtime is not supported by some ubiquitous filesystems (e.g. ext3) so
drop completly this function since it has no added value.
