### PR TITLE
Add tooling to build CD docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ On the next deployment `d4`, the described hierarchy tree will be created in the
 
 ```
 /opt/acme/
-|-> current@ -> /opt/acme/d3
+|-> current@ -> /opt/acme/d4
 |-> d1/
 |-> d2/
 |-> d3/

--- a/misc/.gitlab-ci.yml
+++ b/misc/.gitlab-ci.yml
@@ -1,0 +1,7 @@
+build-and-push:
+  only:
+    - main
+  script:
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
+    - docker build -t "$CI_REGISTRY_IMAGE" -f "Dockerfile-mco" .
+    - docker push "$CI_REGISTRY_IMAGE"

--- a/misc/Dockerfile-choria-enroll
+++ b/misc/Dockerfile-choria-enroll
@@ -1,0 +1,23 @@
+FROM choria/choria
+
+USER root
+
+# Puppet is required for task input validation
+RUN yum -y install wget && \
+    wget 'https://yum.puppetlabs.com/puppet7-release-el-8.noarch.rpm' && \
+    rpm -i puppet7-release-el-8.noarch.rpm && \
+    yum -y install puppet-agent
+
+RUN /opt/puppetlabs/puppet/bin/gem install --bindir /opt/puppetlabs/bin choria-mcorpc-support
+
+RUN groupadd --gid 2049 deploy && \
+    useradd -c "Choria Orchestrator" -m --uid 2049 --gid 2049 deploy && \
+    install -d -o deploy -g deploy -m 0750 /home/deploy/.puppetlabs/etc/puppet/ssl
+
+COPY client.conf /etc/choria/client.conf
+
+ENV USER="deploy"
+
+USER "deploy"
+
+ENTRYPOINT ["/usr/bin/choria", "enroll"]

--- a/misc/Dockerfile-mco
+++ b/misc/Dockerfile-mco
@@ -1,0 +1,25 @@
+FROM choria/choria
+
+USER root
+
+# Puppet is required for task input validation
+RUN yum -y install wget && \
+    wget 'https://yum.puppetlabs.com/puppet7-release-el-8.noarch.rpm' && \
+    rpm -i puppet7-release-el-8.noarch.rpm && \
+    yum -y install puppet-agent
+
+RUN /opt/puppetlabs/puppet/bin/gem install --bindir /opt/puppetlabs/bin choria-mcorpc-support
+
+RUN groupadd --gid 2049 deploy && \
+    useradd -c "Choria Orchestrator" -m --uid 2049 --gid 2049 deploy && \
+    install -d -o deploy -g deploy -m 0750 /home/deploy/.puppetlabs/etc/puppet/ssl
+
+COPY client.conf /etc/choria/client.conf
+
+COPY --chown=deploy:deploy ssl /home/deploy/.puppetlabs/etc/puppet/ssl
+
+ENV USER=deploy
+
+USER deploy
+
+ENTRYPOINT ["/opt/puppetlabs/bin/mco"]

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,0 +1,60 @@
+# Continuous Delivery (CD) Docker image
+
+Use this as a template to build a CD container for your organization.  This container has a `deploy` user which can use choria / mco as a client of your infrastructure.
+
+| File                       | Description                                                                |
+| -------------------------- | -------------------------------------------------------------------------- |
+| `client.conf`              | Base configuration file for choria client                                  |
+| `Dockerfile-mco`           | Rules to build the CD container                                            |
+| `.gitlab-ci.yml`           | GitLab CI configuration to build the CD container and publish it in GitLab |
+| `Dockerfile-choria-enroll` | Rules to build a helper container to populate the `ssl` directory          |
+| `setup-ssl`                | Script to automate the configuration of the `ssl` directory                |
+
+## Preparing client.conf
+
+The `client.conf` need adjusting to fit your site configuration.  When using SRV records (as recommanded for choria deployment), adjust `plugin.choria.srv_domain` with you site domain name.
+
+## Preparing the ssl directory
+
+A `ssl` directory containing the certificate of the CA of your organization and the certificate + key of a deploy user signed by this CA is required for building the CD container.  The layout of this directory is as follow:
+
+```
+ssl
+|-> certs
+|   |-> ca.pem
+|   `-> deploy.mcollective.pem
+`-> private_keys
+    `-> deploy.mcollective.pem
+```
+
+You can either generate these files manualy, or use the `setup-ssl` script to do this automatically.  When using the script, an enrollment container will be created and run.  Connect to your puppet server and sign the certificate using `puppetserver ca sign --certname deploy.mcollective`, and the container will terminate and be removed, but the ssl directory will be ready to use.
+
+## Setup using GitLab
+
+1. Create an new project and copy the files from this directory at the root of it;
+2. Adjust the connection settings in `client.conf` (see above);
+3. Setup the `ssl` directory and add it to the repository (see above);
+4. Commit and push your code so that GitLab CI build the CD container and makes it available.
+
+## Manual Setup
+
+1. Adjust the connection settings in `client.conf` (see above);
+2. Setup the `ssl` directory (see above);
+3. Build the CI/CD container using `docker build .`.
+
+## Using the CD container
+
+Assuming you setup a GitLab project `image-builder/mco` in a registry named `registry.example.com`, add a deploy step as follow to deploy the *foo* application:
+
+```yaml
+deloy:
+  stage: deploy
+  only:
+    - main
+  needs:
+    - build artifact
+  image:
+    name: registry.example.com/image-builder/mco
+    entrypoint: [""]
+  script: /opt/puppetlabs/bin/mco tasks run application::deploy --application=foo --environment=production --url="${URL}" --deployment_name="${CI_COMMIT_SHA}" -C profile::foo
+```

--- a/misc/client.conf
+++ b/misc/client.conf
@@ -1,0 +1,4 @@
+connector = nats
+loglevel = warn
+plugin.choria.srv_domain = FIXME
+securityprovider = choria

--- a/misc/setup-ssl
+++ b/misc/setup-ssl
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -e
+
+if [ -d ssl ]; then
+	echo "Directory ssl already exists" >&2
+	exit 1
+fi
+
+set -x
+
+docker build -f Dockerfile-choria-enroll -t opuscodium/choria-enroll .
+install -d -o 2049 -g 2049 -m 750 ssl
+docker run -it --rm -v $PWD/ssl:/home/deploy/.puppetlabs/etc/puppet/ssl opuscodium/choria-enroll
+docker rmi opuscodium/choria-enroll


### PR DESCRIPTION
Copy-pasta of the README:

----

# Continuous Delivery (CD) Docker image

Use this as a template to build a CD container for your organization.  This container has a `deploy` user which can use choria / mco as a client of your infrastructure.

| File                       | Description                                                                |
| -------------------------- | -------------------------------------------------------------------------- |
| `client.conf`              | Base configuration file for choria client                                  |
| `Dockerfile-mco`           | Rules to build the CD container                                            |
| `.gitlab-ci.yml`           | GitLab CI configuration to build the CD container and publish it in GitLab |
| `Dockerfile-choria-enroll` | Rules to build a helper container to populate the `ssl` directory          |
| `setup-ssl`                | Script to automate the configuration of the `ssl` directory                |

## Preparing client.conf

The `client.conf` need adjusting to fit your site configuration.  When using SRV records (as recommanded for choria deployment), adjust `plugin.choria.srv_domain` with you site domain name.

## Preparing the ssl directory

A `ssl` directory containing the certificate of the CA of your organization and the certificate + key of a deploy user signed by this CA is required for building the CD container.  The layout of this directory is as follow:

```
ssl
|-> certs
|   |-> ca.pem
|   `-> deploy.mcollective.pem
`-> private_keys
    `-> deploy.mcollective.pem
```

You can either generate these files manualy, or use the `setup-ssl` script to do this automatically.  When using the script, an enrollment container will be created and run.  Connect to your puppet server and sign the certificate using `puppetserver ca sign --certname deploy.mcollective`, and the container will terminate and be removed, but the ssl directory will be ready to use.

## Setup using GitLab

1. Create an new project and copy the files from this directory at the root of it;
2. Adjust the connection settings in `client.conf` (see above);
3. Setup the `ssl` directory and add it to the repository (see above);
4. Commit and push your code so that GitLab CI build the CD container and makes it available.

## Manual Setup

1. Adjust the connection settings in `client.conf` (see above);
2. Setup the `ssl` directory (see above);
3. Build the CI/CD container using `docker build .`.

## Using the CD container

Assuming you setup a GitLab project `image-builder/mco` in a registry named `registry.example.com`, add a deploy step as follow to deploy the *foo* application:

```yaml
deloy:
  stage: deploy
  only:
    - main
  needs:
    - build artifact
  image:
    name: registry.example.com/image-builder/mco
    entrypoint: [""]
  script: /opt/puppetlabs/bin/mco tasks run application::deploy --application=foo --environment=production --url="${URL}" --deployment_name="${CI_COMMIT_SHA}" -C profile::foo
```
