### PR TITLE
Allow configuring the number of deployments to keep

### DIFF
--- a/features/deployments.feature
+++ b/features/deployments.feature
@@ -47,3 +47,28 @@ Feature: Deployments
     Then the deployments should be:
       | name      |
       | v5-works  |
+  Scenario: Automatic prunning of deployments
+    Given an application "app1" with retention 1..2
+    And the following deployments:
+      | name |
+      | v1   |
+      | v2   |
+    When I create a deployment "v3"
+    Then the deployments should be:
+      | name |
+      | v2   |
+      | v3   |
+  Scenario: Minimum number of deployments
+    Given an application "app1" with retention 3..5
+    And the following deployments:
+      | name |
+      | v1   |
+      | v2   |
+      | v3   |
+      | v4   |
+    When I prune old deployments keeping the last 1
+    Then the deployments should be:
+      | name |
+      | v2   |
+      | v3   |
+      | v4   |

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -1,9 +1,19 @@
 require_relative '../../tasks/utils/application'
 
 Given('an application {string}') do |application|
+  step(%(an application "#{application}" with retention 1..∞))
+end
+
+Given('an application {string} with retention {int}..{word}') do |application, min, max|
+  max = if max == '∞'
+          nil
+        else
+          Integer(max)
+        end
+
   @tmp_dir = Dir.mktmpdir
   @application_dir = "#{@tmp_dir}/#{application}"
-  @application = Application.new(name: application, path: @application_dir, environment: 'production', deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: {}, group_mapping: {})
+  @application = Application.new(name: application, path: @application_dir, environment: 'production', deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: {}, group_mapping: {}, retention_min: min, retention_max: max)
 end
 
 Given('the following deployments:') do |table|

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,8 @@
 # @param user_mapping User mapping for managing deployment file permissions
 # @param group_mapping Group mapping for managing deployment file permissions
 # @param kind Kind of the application to deploy
+# @param retention_min Minimum number of deployments to keep on disk when pruning
+# @param retention_max Maximum number of deployments to keep on disk after deploying a new deployment (enable auto-pruning)
 define application (
   String[1] $application,
   String[1] $environment,
@@ -17,6 +19,8 @@ define application (
   Hash[String[1], String[1]] $user_mapping  = {},
   Hash[String[1], String[1]] $group_mapping = $user_mapping,
   Optional[String[1]] $kind                 = undef,
+  Integer[1] $retention_min                 = 5,
+  Optional[Integer[1]] $retention_max       = undef,
 ) {
   include application::common
 
@@ -33,6 +37,8 @@ define application (
         deploy_group  => $deploy_group,
         user_mapping  => $user_mapping,
         group_mapping => $group_mapping,
+        retention_min => $retention_min,
+        retention_max => $retention_max,
       },
     ].to_yaml.regsubst("\\A---\n", ''),
   }

--- a/spec/unit/tasks/utils/application_spec.rb
+++ b/spec/unit/tasks/utils/application_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../../../../tasks/utils/application'
 
 RSpec.describe Application do
-  subject(:application) { described_class.new(name: 'app', environment: 'production', path: path, deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: {}, group_mapping: {}) }
+  subject(:application) { described_class.new(name: 'app', environment: 'production', path: path, deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: {}, group_mapping: {}, retention_min: 5, retention_max: nil) }
 
   let(:path) { Dir.mktmpdir }
 

--- a/spec/unit/tasks/utils/deployment_spec.rb
+++ b/spec/unit/tasks/utils/deployment_spec.rb
@@ -12,7 +12,7 @@ end
 RSpec.describe Deployment do
   subject(:deployment) { described_class.new(application, deployment_name) }
 
-  let(:application) { Application.new(name: 'app', environment: 'production', path: path, deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: user_mapping, group_mapping: group_mapping) }
+  let(:application) { Application.new(name: 'app', environment: 'production', path: path, deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: user_mapping, group_mapping: group_mapping, retention_min: 5, retention_max: nil) }
   let(:deployment_name) { '12345678' }
 
   let(:path) { Dir.mktmpdir }
@@ -56,7 +56,7 @@ RSpec.describe Deployment do
     end
 
     context 'with another application' do
-      let(:other_application) { Application.new(name: 'another-instance-with-the-same-path', environment: 'production', path: path, deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: user_mapping, group_mapping: group_mapping) }
+      let(:other_application) { Application.new(name: 'another-instance-with-the-same-path', environment: 'production', path: path, deploy_user: Process.uid, deploy_group: Process.gid, user_mapping: user_mapping, group_mapping: group_mapping, retention_min: 5, retention_max: nil) }
 
       context 'with the same deployment name' do
         let(:other_deployment_name) { deployment_name }


### PR DESCRIPTION
On purge, cap the number of deployments to keep to the value of
`$retention_min`.  On deploy, if `$retention_max` is set, auto-prune
deployments beyond that limit.
