### PR TITLE
Rely on Puppet 7.16 ablitiy to use the system store

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 8.0.0"
+      "version_requirement": ">= 7.16.0 < 8.0.0"
     }
   ]
 }


### PR DESCRIPTION
Now that https://github.com/puppetlabs/puppet/pull/8887 is merged, we
can remove our workaroud and rely on this.
