### PR TITLE
Allow passing custom headers to fetch artifacts

### DIFF
--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -23,7 +23,7 @@ Given('the following deployments:') do |table|
 end
 
 When('I create a deployment {string}') do |name|
-  @application.deploy(nil, name)
+  @application.deploy(nil, name, {})
   workaround_async_ci
 end
 

--- a/spec/unit/tasks/utils/application_spec.rb
+++ b/spec/unit/tasks/utils/application_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Application do
   let(:path) { Dir.mktmpdir }
 
   before do
-    application.deploy(nil, '1')
-    application.deploy(nil, '2')
+    application.deploy(nil, '1', {})
+    application.deploy(nil, '2', {})
   end
 
   after do

--- a/spec/unit/tasks/utils/deployment_spec.rb
+++ b/spec/unit/tasks/utils/deployment_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe Deployment do
 
     before do
       artifact = double
-      allow(Artifact).to receive(:new).with(url).and_return(artifact)
+      allow(Artifact).to receive(:new).with(url, {}).and_return(artifact)
       allow(artifact).to receive(:extract_to)
       allow(artifact).to receive(:unlink)
       allow(application).to receive(:setup_persistent_data)
@@ -124,7 +124,7 @@ RSpec.describe Deployment do
       allow(deployment).to receive(:hook_path).with('before_deploy').and_return(fixture('success_hook'))
       allow(deployment).to receive(:hook_path).with('after_deploy').and_return(fixture('success_hook'))
 
-      expect(deployment.deploy(url)).to be_truthy
+      expect(deployment.deploy(url, {})).to be_truthy
       expect(deployment).to have_received(:run_hook).with('before_deploy')
       expect(deployment).to have_received(:run_hook).with('after_deploy')
     end
@@ -133,7 +133,7 @@ RSpec.describe Deployment do
       allow(deployment).to receive(:hook_path).with('before_deploy').and_return(fixture('failure_hook'))
       allow(deployment).to receive(:hook_path).with('after_deploy').and_return(fixture('success_hook'))
 
-      expect { deployment.deploy(url) }.to raise_exception('Aborted deployment: before_deploy hook failed')
+      expect { deployment.deploy(url, {}) }.to raise_exception('Aborted deployment: before_deploy hook failed')
       expect(deployment).to have_received(:run_hook).with('before_deploy')
       expect(deployment).not_to have_received(:run_hook).with('after_deploy')
     end
@@ -142,7 +142,7 @@ RSpec.describe Deployment do
       allow(deployment).to receive(:hook_path).with('before_deploy').and_return(fixture('success_hook'))
       allow(deployment).to receive(:hook_path).with('after_deploy').and_return(fixture('failure_hook'))
 
-      expect(deployment.deploy(url)).to be_falsey
+      expect(deployment.deploy(url, {})).to be_falsey
       expect(deployment).to have_received(:run_hook).with('before_deploy')
       expect(deployment).to have_received(:run_hook).with('after_deploy')
     end

--- a/tasks/deploy.json
+++ b/tasks/deploy.json
@@ -25,6 +25,10 @@
     "deployment_name": {
       "description": "The name of the deployment to create",
       "type": "Optional[String[1]]"
+    },
+    "headers": {
+      "description": "Extra HTTP headers",
+      "type": "Optional[Hash[String[1], String[1]]]"
     }
   }
 }

--- a/tasks/deploy.rb
+++ b/tasks/deploy.rb
@@ -6,9 +6,9 @@ require_relative '../../ruby_task_helper/files/task_helper'
 require_relative 'utils/application_factory'
 
 class ApplicationDeployTask < TaskHelper
-  def task(application:, environment:, url:, deployment_name: nil, **_kwargs)
+  def task(application:, environment:, url:, deployment_name: nil, headers: {}, **_kwargs)
     ApplicationFactory.find(application, environment).each do |app|
-      app.deploy(url, deployment_name)
+      app.deploy(url, deployment_name, headers)
     end
 
     nil

--- a/tasks/utils/application.rb
+++ b/tasks/utils/application.rb
@@ -22,8 +22,8 @@ class Application
     @retention_max = retention_max
   end
 
-  def deploy(url, deployment_name)
-    deployment = Deployment.create(self, deployment_name, url)
+  def deploy(url, deployment_name, headers)
+    deployment = Deployment.create(self, deployment_name, url, headers)
 
     deployment.activate
 

--- a/tasks/utils/artifact.rb
+++ b/tasks/utils/artifact.rb
@@ -7,22 +7,22 @@ require 'tempfile'
 class Artifact
   attr_reader :deployment_name
 
-  def initialize(url = nil)
+  def initialize(url = nil, headers = {})
     @tmp_file = Tempfile.open('archive')
     @tmp_file.close
     FileUtils.chmod(0o600, @tmp_file.path)
 
     return unless url
 
-    download(url)
+    download(url, headers)
     @deployment_name = read_deployment_name
   end
 
-  def download(url)
+  def download(url, headers)
     initialize_puppet
     client = Puppet.runtime[:http]
     ssl_provider = Puppet::SSL::SSLProvider.new
-    client.get(URI(url), options: { ssl_context: ssl_provider.load_context(revocation: false, include_system_store: true) }) do |response|
+    client.get(URI(url), headers: headers, options: { ssl_context: ssl_provider.load_context(revocation: false, include_system_store: true) }) do |response|
       raise 'Failed to download artifact' unless response.success?
 
       File.open(@tmp_file.path, 'w') do |f|

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -24,14 +24,14 @@ class Deployment
     @path = File.join(application.path, name)
   end
 
-  def self.create(application, name, url)
+  def self.create(application, name, url, headers)
     deployment = Deployment.new(application, name)
-    deployment.deploy(url)
+    deployment.deploy(url, headers)
     deployment
   end
 
-  def deploy(url)
-    artifact = Artifact.new(url)
+  def deploy(url, headers)
+    artifact = Artifact.new(url, headers)
     @name ||= artifact.deployment_name
 
     raise 'Cannot infer deployment name and none specified' if name.nil?


### PR DESCRIPTION
This allows us to rely on GitLab's [GitLab Generic Packages Repository] where we can use short-lived CI/CD job tokens to download artifacts:

```yaml
variables:
  URL: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/generic/foo/${CI_COMMIT_TAG}/artifact.tar.gz"

package:
  stage: package
  only:
    - tags
  script:
    - tar zcf /tmp/artifact.tar.gz --exclude .git .
    - curl --fail --header "JOB-TOKEN: $CI_JOB_TOKEN" --upload-file /tmp/artifact.tar.gz "${URL}"'

deploy:
  stage: deploy
  only:
    - tags
  needs:
    - package
  image:
    name: registry.example.com/image-builder/mco
  script: 'mco tasks run application::deploy --application=foo --environment=production --url="${URL}" --deployment_name="${CI_COMMIT_TAG}" --header="{\"JOB-TOKEN\": \"${CI_JOB_TOKEN}\"}" -C profile::foo'
```
[GitLab Generic Packages Repository]: https://docs.gitlab.com/ee/user/packages/generic_packages/