### PR TITLE
Fix listing applications when requiements are missing

### DIFF
--- a/spec/unit/tasks/utils/deployment_spec.rb
+++ b/spec/unit/tasks/utils/deployment_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+require 'mtree'
+
 require_relative '../../../../tasks/utils/application'
 require_relative '../../../../tasks/utils/deployment'
 

--- a/tasks/utils/application_factory.rb
+++ b/tasks/utils/application_factory.rb
@@ -38,6 +38,8 @@ class ApplicationFactory
 
   def self.load_configuration_metadata
     YAML.safe_load(File.read(ApplicationsHelper.instance.configuration_metadata))
+  rescue Errno::ENOENT
+    {}
   end
 
   private_class_method :configuration_metadata_for, :load_configuration_metadata

--- a/tasks/utils/artifact.rb
+++ b/tasks/utils/artifact.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'minitar'
 require 'puppet'
 require 'tempfile'
 
@@ -60,6 +59,7 @@ class Artifact
   def read_deployment_name
     res = nil
 
+    require 'minitar'
     Zlib::GzipReader.open(@tmp_file.path) do |io|
       Minitar.open(io) do |tar|
         tar.each_entry do |entry|

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'fileutils'
-require 'mtree'
 
 require_relative 'applications_helper'
 require_relative 'artifact'
@@ -162,6 +161,7 @@ class Deployment
 
     return nil unless File.exist?(mtree_file)
 
+    require 'mtree'
     parser = Mtree::Parser.new
     parser.parse_file(mtree_file)
     parser.specifications


### PR DESCRIPTION
If the module requirements are missing, an exception is raised when loading the code used for listing applications.
