### PR TITLE
Raise an error if no matching application is found

### DIFF
--- a/spec/unit/tasks/utils/application_factory_spec.rb
+++ b/spec/unit/tasks/utils/application_factory_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative '../../../../tasks/utils/application_factory'
+
+RSpec.describe ApplicationFactory do
+  describe '::find' do
+    subject { described_class.find('app1', 'production') }
+
+    before do
+      allow(Application).to receive(:new).and_return(double)
+    end
+
+    context 'application is configured' do
+      before do
+        allow(described_class).to receive(:load_configuration_metadata).and_return([
+                                                                                     {
+                                                                                       'title'       => 'foo',
+                                                                                       'application' => 'app1',
+                                                                                       'environment' => 'production',
+                                                                                     },
+                                                                                     {
+                                                                                       'title'       => 'bar',
+                                                                                       'application' => 'app1',
+                                                                                       'environment' => 'development',
+                                                                                     },
+                                                                                     {
+                                                                                       'title'       => 'baz',
+                                                                                       'application' => 'app2',
+                                                                                       'environment' => 'development',
+                                                                                     },
+                                                                                     {
+                                                                                       'title'       => 'qux',
+                                                                                       'application' => 'app1',
+                                                                                       'environment' => 'production',
+                                                                                     },
+                                                                                   ])
+      end
+
+      it { is_expected.to be_an(Array) }
+      it { is_expected.to have_attributes(size: 2) }
+    end
+    context 'no application is configured' do
+      before do
+        allow(described_class).to receive(:load_configuration_metadata).and_return([])
+      end
+
+      it { expect { subject }.to raise_error('No match for application app1 in environment production') }
+    end
+  end
+end

--- a/tasks/utils/application_factory.rb
+++ b/tasks/utils/application_factory.rb
@@ -12,9 +12,13 @@ class ApplicationFactory
   end
 
   def self.find(application, environment)
-    configuration_metadata_for(application, environment).map do |spec|
+    res = configuration_metadata_for(application, environment).map do |spec|
       Application.new(spec)
     end
+
+    raise "No match for application #{application} in environment #{environment}" if res.empty?
+
+    res
   end
 
   def self.configuration_metadata_for(application, environment)


### PR DESCRIPTION
When searching for deployments for an application and an environment,
raise an exception if none is found.  Previously we ignored this and
just did nothing.
