### PR TITLE
Add support for extracting more archive formats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ group :test do
   gem 'voxpupuli-test', '~> 2.1',  :require => false
   gem 'simplecov-console',         :require => false
   gem 'cucumber',                  :require => false
-  gem 'minitar',                   :require => false
   gem 'mtree',                     :require => false
 end
 group :development do

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -25,5 +25,5 @@ class application::common (
     mode   => '0644',
   }
 
-  ensure_packages(['minitar', 'mtree'], { ensure => installed, provider => $gem_dependencies_provider })
+  ensure_packages(['mtree'], { ensure => installed, provider => $gem_dependencies_provider })
 }

--- a/spec/unit/tasks/utils/artifact_spec.rb
+++ b/spec/unit/tasks/utils/artifact_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative '../../../../tasks/utils/artifact'
+
+RSpec.describe Artifact do
+  describe '#common_root' do
+    subject { described_class.new.common_root(filenames) }
+
+    context('with a single root file') do
+      let(:filenames) do
+        [
+          'file_a',
+        ]
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context('with many root files') do
+      let(:filenames) do
+        %w[
+          file_a
+          file_b
+        ]
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context('with a common root') do
+      let(:filenames) do
+        [
+          'root/',
+          'root/subdirectory/',
+          'root/subdirectory/file',
+        ]
+      end
+
+      it { is_expected.to eq('root') }
+    end
+
+    context 'with root files and directories' do
+      let(:filenames) do
+        [
+          'directory_a/',
+          'directory_a/file_a',
+          'directory_a/file_b',
+          'directory_b/',
+          'directory_b/file_c',
+        ]
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Rely on GNU tar -a to detect the file type base on it's extension and
use the appropriate program to decompress the archive.

Bring support for e.g. .tar.bz2 and allows us to prune the minitar
dependency.