### PR TITLE
Raise an exception when an after_deploy/after_activate hook fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: development:test:release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -48,7 +48,7 @@ jobs:
       PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -73,7 +73,7 @@ jobs:
         run: |
           echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
           sudo service docker restart
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/spec/unit/tasks/utils/deployment_spec.rb
+++ b/spec/unit/tasks/utils/deployment_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Deployment do
       allow(deployment).to receive(:hook_path).with('before_deploy').and_return(fixture('success_hook'))
       allow(deployment).to receive(:hook_path).with('after_deploy').and_return(fixture('success_hook'))
 
-      expect(deployment.deploy(url, {})).to be_truthy
+      expect { deployment.deploy(url, {}) }.not_to raise_exception
       expect(deployment).to have_received(:run_hook).with('before_deploy')
       expect(deployment).to have_received(:run_hook).with('after_deploy')
     end
@@ -144,7 +144,7 @@ RSpec.describe Deployment do
       allow(deployment).to receive(:hook_path).with('before_deploy').and_return(fixture('success_hook'))
       allow(deployment).to receive(:hook_path).with('after_deploy').and_return(fixture('failure_hook'))
 
-      expect(deployment.deploy(url, {})).to be_falsey
+      expect { deployment.deploy(url, {}) }.to raise_exception('after_deploy hook failed')
       expect(deployment).to have_received(:run_hook).with('before_deploy')
       expect(deployment).to have_received(:run_hook).with('after_deploy')
     end

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -49,7 +49,7 @@ class Deployment
         raise e
       end
     end
-    run_hook('after_deploy')
+    raise 'after_deploy hook failed' unless run_hook('after_deploy')
   end
 
   def active?

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -80,7 +80,7 @@ class Deployment
     FileUtils.rm_f(application.current_link_path)
     FileUtils.ln_s(path, application.current_link_path)
     FileUtils.touch(path)
-    run_hook('after_activate')
+    raise 'after_activate hook failed' unless run_hook('after_activate')
   end
 
   def updated_at


### PR DESCRIPTION
This prevent the new deployment from being activated, but we keep the
files in place: a manual intervention might be required e.g. to restore
database at the state they where before we tried to create a new
deployment.

Previously, an error was silently ignored and could not be catch.
