### PR TITLE
Fix task execution with Ruby 3.2

### DIFF
--- a/tasks/utils/application_factory.rb
+++ b/tasks/utils/application_factory.rb
@@ -13,7 +13,7 @@ class ApplicationFactory
 
   def self.find(application, environment)
     res = configuration_metadata_for(application, environment).map do |spec|
-      Application.new(spec)
+      Application.new(**spec)
     end
 
     raise "No match for application #{application} in environment #{environment}" if res.empty?


### PR DESCRIPTION
Puppet 8 bundle Ruby 3.2, and kwargs auto-promotion is not done anymore
with this version.
