### PR TITLE
Update docker instructions

### DIFF
--- a/misc/Dockerfile-choria-enroll
+++ b/misc/Dockerfile-choria-enroll
@@ -1,11 +1,11 @@
-FROM choria/choria
+FROM registry.choria.io/choria/choria:0.29.4
 
 USER root
 
 # Puppet is required for task input validation
 RUN yum -y install wget && \
-    wget 'https://yum.puppetlabs.com/puppet7-release-el-8.noarch.rpm' && \
-    rpm -i puppet7-release-el-8.noarch.rpm && \
+    wget 'https://yum.puppetlabs.com/puppet8-release-el-9.noarch.rpm' && \
+    rpm -i puppet8-release-el-9.noarch.rpm && \
     yum -y install puppet-agent
 
 RUN /opt/puppetlabs/puppet/bin/gem install --bindir /opt/puppetlabs/bin choria-mcorpc-support

--- a/misc/Dockerfile-mco
+++ b/misc/Dockerfile-mco
@@ -1,11 +1,11 @@
-FROM choria/choria
+FROM registry.choria.io/choria/choria:0.29.4
 
 USER root
 
 # Puppet is required for task input validation
 RUN yum -y install wget && \
-    wget 'https://yum.puppetlabs.com/puppet7-release-el-8.noarch.rpm' && \
-    rpm -i puppet7-release-el-8.noarch.rpm && \
+    wget 'https://yum.puppetlabs.com/puppet8-release-el-9.noarch.rpm' && \
+    rpm -i puppet8-release-el-9.noarch.rpm && \
     yum -y install puppet-agent
 
 RUN /opt/puppetlabs/puppet/bin/gem install --bindir /opt/puppetlabs/bin choria-mcorpc-support


### PR DESCRIPTION
A few things have changed since these Dockerfiles where introduced:
* The choria registry has changed;
* The choria image is now based on AlmaLinux 9;
* Puppet 8 is required to run choria.

While here, make builds somewhat more reproducible by setting an explicit choria version.
