### PR TITLE
Fix read_deployment_name on FreeBSD

### DIFF
--- a/tasks/utils/artifact.rb
+++ b/tasks/utils/artifact.rb
@@ -58,7 +58,7 @@ class Artifact
   end
 
   def read_deployment_name
-    output = Puppet::Util::Execution.execute(['tar', 'atf', @tmp_file.path], failonfail: true)
+    output = Puppet::Util::Execution.execute(['tar', 'tf', @tmp_file.path], failonfail: true)
 
     common_root(output.lines.map(&:chomp))
   end


### PR DESCRIPTION
On FreeBSD, `atf` fail with:

```
tar: Option -a is not permitted in mode -t
```

GNU tar seems to be happy with just `tf` so stick to this.
