### PR TITLE
Allow `file://` URI scheme

### DIFF
--- a/tasks/utils/artifact.rb
+++ b/tasks/utils/artifact.rb
@@ -58,7 +58,7 @@ class Artifact
   end
 
   def read_deployment_name
-    output = Puppet::Util::Execution.execute(['tar', 'atf', @tmp_file.path], failonfail: true)
+    output = Puppet::Util::Execution.execute(['tar', 'tf', @tmp_file.path], failonfail: true)
 
     common_root(output.lines.map(&:chomp))
   end


### PR DESCRIPTION
This allow to deploy an artifact which is already available using a
`file://` URI.  Only files from the local host are supported.

The artifact is only removed if it was downloaded during deployment.

Also include:
  * #52
