### PR TITLE
Fix deployment path inference

### DIFF
--- a/tasks/utils/artifact.rb
+++ b/tasks/utils/artifact.rb
@@ -75,7 +75,7 @@ class Artifact
   end
 
   def common_root(filenames)
-    roots = filenames.select { |item| item[-1] == '/' }.map { |item| item.split('/', 2).first }.uniq
+    roots = filenames.map { |item| item.sub(%r{^\./}, '') }.select { |item| item[-1] == '/' }.map { |item| item.split('/', 2).first }.uniq
 
     roots.first if roots.size == 1
   end

--- a/tasks/utils/deployment.rb
+++ b/tasks/utils/deployment.rb
@@ -8,7 +8,7 @@ require_relative 'artifact'
 class Deployment
   include Comparable
 
-  attr_reader :application, :name, :path
+  attr_reader :application, :name
 
   def <=>(other)
     res = application <=> other.application
@@ -20,13 +20,18 @@ class Deployment
   def initialize(application, name)
     @application = application
     @name = name
-    @path = File.join(application.path, name)
   end
 
   def self.create(application, name, url, headers)
     deployment = Deployment.new(application, name)
     deployment.deploy(url, headers)
     deployment
+  end
+
+  def path
+    raise 'Deployment has currently no name' if name.nil?
+
+    @path ||= File.join(application.path, name)
   end
 
   def deploy(url, headers)


### PR DESCRIPTION
The deployment name is optional, but the way the deployment path was computed made it mandatory to provide it.

This revert the initial behavior where the deployment name is found by inspecting the content of the artifact to deploy when all files contained in this artifact are located in a single root directory.
