### PR TITLE
Use an AIO-agnostic path to Ruby for tasks

### DIFF
--- a/tasks/activate.rb
+++ b/tasks/activate.rb
@@ -1,4 +1,4 @@
-#!/opt/puppetlabs/puppet/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative '../../ruby_task_helper/files/task_helper'

--- a/tasks/deploy.rb
+++ b/tasks/deploy.rb
@@ -1,4 +1,4 @@
-#!/opt/puppetlabs/puppet/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative '../../ruby_task_helper/files/task_helper'

--- a/tasks/list.rb
+++ b/tasks/list.rb
@@ -1,4 +1,4 @@
-#!/opt/puppetlabs/puppet/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative '../../ruby_task_helper/files/task_helper'

--- a/tasks/prune.rb
+++ b/tasks/prune.rb
@@ -1,4 +1,4 @@
-#!/opt/puppetlabs/puppet/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative '../../ruby_task_helper/files/task_helper'

--- a/tasks/remove.rb
+++ b/tasks/remove.rb
@@ -1,4 +1,4 @@
-#!/opt/puppetlabs/puppet/bin/ruby
+#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require_relative '../../ruby_task_helper/files/task_helper'


### PR DESCRIPTION
When running tasks with bolt, we can force an interpreter based on the
extension of the task we run.  With choria, the shebang is respected.
Bolt keep the user environment as is, and Choria makes sure the AIO path
is prepended before spawning the process in a clean environment, so this
is supposed to be backwards compatible and only less a PITA for users of
non-AIO Puppet.
